### PR TITLE
Remove -q from Playwright install commands

### DIFF
--- a/create-webui-user-lxc.sh
+++ b/create-webui-user-lxc.sh
@@ -113,7 +113,7 @@ ct_exec "echo '$USERNAME:$PASSWORD' | chpasswd"
 ct_exec "adduser $USERNAME sudo"
 
 info "Cloning browser-use/web-ui…"
-ct_exec "sudo -u $USERNAME -H bash -c 'cd ~ && git clone https://github.com/browser-use/web-ui.git web-ui && cd web-ui && python3 -m venv venv && . venv/bin/activate && pip install --upgrade pip -q && pip install -r requirements.txt -q && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chromium -q'"
+ct_exec "sudo -u $USERNAME -H bash -c 'cd ~ && git clone https://github.com/browser-use/web-ui.git web-ui && cd web-ui && python3 -m venv venv && . venv/bin/activate && pip install --upgrade pip -q && pip install -r requirements.txt -q && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chromium'"
 
 info "Cloning noVNC…"
 ct_exec "sudo -u $USERNAME git clone https://github.com/novnc/noVNC.git /home/$USERNAME/web-ui/noVNC"

--- a/update-webui.sh
+++ b/update-webui.sh
@@ -40,7 +40,7 @@ pct exec "$CTID" -- bash -Eeuo pipefail <<'EOF'
   # Instalar nuevas dependencias
   pip install -r requirements.txt -q
   # Actualizar Playwright
-  PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chromium -q
+  PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chromium
   # Reiniciar servicios
   supervisorctl restart webui novnc
 EOF


### PR DESCRIPTION
## Summary
- ensure Playwright install runs verbosely in user LXC installer
- do the same for the update script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a723cf5d08327bbc616f6cab3b990