### PR TITLE
Use Chrome and move data dirs

### DIFF
--- a/create-webui-lxc.sh
+++ b/create-webui-lxc.sh
@@ -111,7 +111,11 @@ ct_exec "cd /opt && git clone https://github.com/browser-use/web-ui.git && \
   cd /opt/web-ui && python3 -m venv venv && . venv/bin/activate && \
   pip install --upgrade pip -q && pip install -r requirements.txt \
   playwright lxml_html_clean -q && \
-  PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chromium"
+  PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chrome"
+
+info "Adjusting default directories…"
+ct_exec "mkdir -p /opt/web-ui/data"
+ct_exec "find /opt/web-ui/src -type f -name '*.py' -exec sed -i 's|./tmp/|./data/|g' {} +"
 
 ct_exec "git clone https://github.com/novnc/noVNC.git /opt/web-ui/noVNC"
 

--- a/create-webui-user-lxc.sh
+++ b/create-webui-user-lxc.sh
@@ -112,8 +112,15 @@ ct_exec "useradd -m -s /bin/bash $USERNAME"
 ct_exec "echo '$USERNAME:$PASSWORD' | chpasswd"
 ct_exec "adduser $USERNAME sudo"
 
+info "Preparing Playwright browsers directory…"
+ct_exec "mkdir -p /ms-playwright && chown $USERNAME:$USERNAME /ms-playwright"
+
 info "Cloning browser-use/web-ui…"
-ct_exec "sudo -u $USERNAME -H bash -c 'cd ~ && git clone https://github.com/browser-use/web-ui.git web-ui && cd web-ui && python3 -m venv venv && . venv/bin/activate && pip install --upgrade pip -q && pip install -r requirements.txt -q && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chromium -q'"
+ct_exec "sudo -u $USERNAME -H bash -c 'cd ~ && git clone https://github.com/browser-use/web-ui.git web-ui && cd web-ui && python3 -m venv venv && . venv/bin/activate && pip install --upgrade pip -q && pip install -r requirements.txt -q && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chrome'"
+
+info "Adjusting default directories…"
+ct_exec "sudo -u $USERNAME mkdir -p /home/$USERNAME/web-ui/data"
+ct_exec "sudo -u $USERNAME bash -c 'find /home/$USERNAME/web-ui/src -type f -name \"*.py\" -exec sed -i \"s|./tmp/|./data/|g\" {} +'"
 
 info "Cloning noVNC…"
 ct_exec "sudo -u $USERNAME git clone https://github.com/novnc/noVNC.git /home/$USERNAME/web-ui/noVNC"

--- a/update-webui.sh
+++ b/update-webui.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 # Detecta el CT que contiene /opt/web-ui y ejecuta:
 #  - git pull
 #  - pip install -r requirements.txt
-#  - playwright install chromium
+#  - playwright install chrome
 #  - reinicia servicios supervisor (webui, novnc)
 # ----------------------------------------------------------------------------
 
@@ -40,7 +40,8 @@ pct exec "$CTID" -- bash -Eeuo pipefail <<'EOF'
   # Instalar nuevas dependencias
   pip install -r requirements.txt -q
   # Actualizar Playwright
-  PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chromium -q
+  PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chrome
+  find /opt/web-ui/src -type f -name '*.py' -exec sed -i 's|./tmp/|./data/|g' {} +
   # Reiniciar servicios
   supervisorctl restart webui novnc
 EOF


### PR DESCRIPTION
## Summary
- ensure Playwright install grabs Chrome
- configure default data directories under `data/` instead of `tmp/`
- apply these updates in install and update scripts

## Testing
- `bash -n create-webui-user-lxc.sh`
- `bash -n create-webui-lxc.sh`
- `bash -n update-webui.sh`


------
https://chatgpt.com/codex/tasks/task_e_686a723cf5d08327bbc616f6cab3b990